### PR TITLE
Hatch like plant use case, and implement like_plant, login, and logout interactor unit test. 

### DIFF
--- a/src/main/java/interface_adapter/like_plant/LikePlantController.java
+++ b/src/main/java/interface_adapter/like_plant/LikePlantController.java
@@ -1,5 +1,6 @@
 package interface_adapter.like_plant;
 
+import entity.Plant;
 import org.bson.types.ObjectId;
 import use_case.like_plant.LikePlantInputBoundary;
 import use_case.like_plant.LikePlantInputData;
@@ -11,8 +12,8 @@ public class LikePlantController {
         this.likePlantInteractor = likePlantInteractor;
     }
 
-    public void execute(ObjectId plantID) {
-        LikePlantInputData likePlantInputData = new LikePlantInputData(plantID);
+    public void execute(Plant plant) {
+        LikePlantInputData likePlantInputData = new LikePlantInputData(plant);
         likePlantInteractor.execute(likePlantInputData);
     }
 }

--- a/src/main/java/use_case/like_plant/LikePlantInputData.java
+++ b/src/main/java/use_case/like_plant/LikePlantInputData.java
@@ -1,16 +1,17 @@
 package use_case.like_plant;
 
+import entity.Plant;
 import org.bson.types.ObjectId;
 
 public class LikePlantInputData {
 
-    private final ObjectId plantID;
+    private final Plant plant;
 
-    public LikePlantInputData(ObjectId plantID) {
-        this.plantID = plantID;
+    public LikePlantInputData(Plant plant) {
+        this.plant = plant;
     }
 
-    public ObjectId getPlantID() {
-        return plantID;
+    public Plant getPlant() {
+        return plant;
     }
 }

--- a/src/main/java/use_case/like_plant/LikePlantInteractor.java
+++ b/src/main/java/use_case/like_plant/LikePlantInteractor.java
@@ -1,20 +1,18 @@
 package use_case.like_plant;
-
-import interface_adapter.like_plant.LikePlantPresenter;
 import use_case.PlantDataAccessInterface;
 
 public class LikePlantInteractor implements LikePlantInputBoundary {
     private final PlantDataAccessInterface plantDatabase;
-    LikePlantPresenter presenter;
+    LikePlantOutputBoundary presenter;
 
-    public LikePlantInteractor(PlantDataAccessInterface plantDatabase, LikePlantPresenter presenter) {
+    public LikePlantInteractor(PlantDataAccessInterface plantDatabase, LikePlantOutputBoundary presenter) {
         this.plantDatabase = plantDatabase;
         this.presenter = presenter;
     }
 
     @Override
     public void execute(LikePlantInputData input) {
-        plantDatabase.likePlant(input.getPlantID());
+        plantDatabase.likePlant(input.getPlant().getFileID());
         presenter.prepareSuccessView();
     }
 }

--- a/src/main/java/view/gallery/PublicGalleryView.java
+++ b/src/main/java/view/gallery/PublicGalleryView.java
@@ -92,19 +92,20 @@ public class PublicGalleryView extends JPanel implements PropertyChangeListener 
                 JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
                 buttonPanel.setBackground(new Color(236, 245, 233));
 
+                MongoPlantDataAccessObject plantAccess = MongoPlantDataAccessObject.getInstance();
+
                 JButton infoButton = new JButton("Info");
                 infoButton.setBackground(new Color(224, 242, 213));
-
-                MongoPlantDataAccessObject plantAccess = MongoPlantDataAccessObject.getInstance();
-                infoButton.addActionListener(e -> this.displayPlantMap.accept(plantAccess.fetchPlantByID(id)));
+                infoButton.addActionListener(e ->
+                        this.displayPlantMap.accept(plantAccess.fetchPlantByID(id))
+                );
                 buttonPanel.add(infoButton);
 
                 JButton likeButton = new JButton("Like");
                 likeButton.setBackground(new Color(224, 242, 213));
-                likeButton.addActionListener(e -> {
-                    this.likePlantController.execute(id);
-                });
-
+                likeButton.addActionListener(e ->
+                    this.likePlantController.execute(plantAccess.fetchPlantByID(id))
+                );
                 buttonPanel.add(likeButton);
 
                 GridBagConstraints gbc = new GridBagConstraints();

--- a/src/test/java/use_case/LikePlantInteractorTest.java
+++ b/src/test/java/use_case/LikePlantInteractorTest.java
@@ -1,4 +1,33 @@
 package use_case;
+import data_access.InMemoryPlantDataAccessObject;
+import entity.Plant;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+import use_case.like_plant.LikePlantInputBoundary;
+import use_case.like_plant.LikePlantInputData;
+import use_case.like_plant.LikePlantInteractor;
+import use_case.like_plant.LikePlantOutputBoundary;
+import static org.junit.Assert.*;
 
 public class LikePlantInteractorTest {
+    @Test
+    public void successTest() {
+        Plant plant = new Plant();
+        ObjectId plantID = new ObjectId();
+        plant.setFileID(plantID);
+        LikePlantInputData inputData = new LikePlantInputData(plant);
+
+        PlantDataAccessInterface plantRepository = InMemoryPlantDataAccessObject.getInstance();
+        plantRepository.addPlant(plant);
+
+        LikePlantOutputBoundary successPresenter = new LikePlantOutputBoundary() {
+            @Override
+            public void prepareSuccessView() {
+                assertEquals(1, plantRepository.fetchPlantByID(plantID).getNumOfLikes());
+            }
+        };
+
+        LikePlantInputBoundary interactor = new LikePlantInteractor(plantRepository, successPresenter);
+        interactor.execute(inputData);
+    }
 }

--- a/src/test/java/use_case/LikePlantInteractorTest.java
+++ b/src/test/java/use_case/LikePlantInteractorTest.java
@@ -3,11 +3,12 @@ import data_access.InMemoryPlantDataAccessObject;
 import entity.Plant;
 import org.bson.types.ObjectId;
 import org.junit.Test;
+import static org.junit.Assert.*;
 import use_case.like_plant.LikePlantInputBoundary;
 import use_case.like_plant.LikePlantInputData;
 import use_case.like_plant.LikePlantInteractor;
 import use_case.like_plant.LikePlantOutputBoundary;
-import static org.junit.Assert.*;
+
 
 public class LikePlantInteractorTest {
     @Test

--- a/src/test/java/use_case/LoginInteractorTest.java
+++ b/src/test/java/use_case/LoginInteractorTest.java
@@ -1,4 +1,93 @@
 package use_case;
+import data_access.InMemoryUserDataAccessObject;
+import entity.User;
+import org.junit.Test;
+import use_case.login.*;
+
+import static org.junit.Assert.*;
 
 public class LoginInteractorTest {
+    @Test
+    public void successTest() {
+        LoginInputData inputData = new LoginInputData("arz", "123");
+        UserDataAccessInterface userRepository = InMemoryUserDataAccessObject.getInstance();
+
+        // For the success test, we need to add Paul to the data access repository before we log in.
+        User user = new User("arz", "123");
+        userRepository.addUser(user);
+
+        // This creates a successPresenter that tests whether the test case is as we expect.
+        LoginOutputBoundary successPresenter = new LoginOutputBoundary() {
+            @Override
+            public void prepareSuccessView(LoginOutputData user) {
+                assertEquals("arz", user.getUsername());
+            }
+
+            @Override
+            public void prepareFailView(String error) {
+                fail("Use case failure is unexpected.");
+            }
+
+            @Override
+            public void switchToStartView() {}
+        };
+
+        LoginInputBoundary interactor = new LoginInteractor(userRepository, successPresenter);
+        interactor.execute(inputData);
+    }
+
+
+    @Test
+    public void failurePasswordMismatchTest() {
+        LoginInputData inputData = new LoginInputData("arz", "wrong");
+        UserDataAccessInterface userRepository = InMemoryUserDataAccessObject.getInstance();
+
+        User user = new User("arz", "123");
+        userRepository.addUser(user);
+
+        LoginOutputBoundary failurePresenter = new LoginOutputBoundary() {
+            @Override
+            public void prepareSuccessView(LoginOutputData user) {
+                // this should never be reached since the test case should fail
+                fail("Use case success is unexpected.");
+            }
+
+            @Override
+            public void prepareFailView(String error) {
+                assertEquals("Incorrect password for \"arz\".", error);
+            }
+
+            @Override
+            public void switchToStartView() {}
+        };
+
+        LoginInputBoundary interactor = new LoginInteractor(userRepository, failurePresenter);
+        interactor.execute(inputData);
+    }
+
+    @Test
+    public void failureUserDoesNotExistTest() {
+        LoginInputData inputData = new LoginInputData("arz", "123");
+        UserDataAccessInterface userRepository = InMemoryUserDataAccessObject.getInstance();
+
+        LoginOutputBoundary failurePresenter = new LoginOutputBoundary() {
+            @Override
+            public void prepareSuccessView(LoginOutputData user) {
+                // this should never be reached since the test case should fail
+                fail("Use case success is unexpected.");
+            }
+
+            @Override
+            public void prepareFailView(String error) {
+                assertEquals("arz: Account does not exist.", error);
+            }
+
+            @Override
+            public void switchToStartView() {}
+        };
+
+        LoginInputBoundary interactor = new LoginInteractor(userRepository, failurePresenter);
+        interactor.execute(inputData);
+    }
+
 }

--- a/src/test/java/use_case/LoginInteractorTest.java
+++ b/src/test/java/use_case/LoginInteractorTest.java
@@ -12,11 +12,9 @@ public class LoginInteractorTest {
         LoginInputData inputData = new LoginInputData("arz", "123");
         UserDataAccessInterface userRepository = InMemoryUserDataAccessObject.getInstance();
 
-        // For the success test, we need to add Paul to the data access repository before we log in.
         User user = new User("arz", "123");
         userRepository.addUser(user);
 
-        // This creates a successPresenter that tests whether the test case is as we expect.
         LoginOutputBoundary successPresenter = new LoginOutputBoundary() {
             @Override
             public void prepareSuccessView(LoginOutputData user) {
@@ -48,7 +46,6 @@ public class LoginInteractorTest {
         LoginOutputBoundary failurePresenter = new LoginOutputBoundary() {
             @Override
             public void prepareSuccessView(LoginOutputData user) {
-                // this should never be reached since the test case should fail
                 fail("Use case success is unexpected.");
             }
 
@@ -73,7 +70,6 @@ public class LoginInteractorTest {
         LoginOutputBoundary failurePresenter = new LoginOutputBoundary() {
             @Override
             public void prepareSuccessView(LoginOutputData user) {
-                // this should never be reached since the test case should fail
                 fail("Use case success is unexpected.");
             }
 
@@ -89,5 +85,4 @@ public class LoginInteractorTest {
         LoginInputBoundary interactor = new LoginInteractor(userRepository, failurePresenter);
         interactor.execute(inputData);
     }
-
 }

--- a/src/test/java/use_case/LogoutInteractorTest.java
+++ b/src/test/java/use_case/LogoutInteractorTest.java
@@ -1,4 +1,35 @@
 package use_case;
 
+import data_access.InMemoryUserDataAccessObject;
+import entity.User;
+import org.junit.Test;
+import use_case.logout.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 public class LogoutInteractorTest {
+    @Test
+    public void successTest() {
+        LogoutInputData inputData = new LogoutInputData("arz");
+        UserDataAccessInterface userRepository = InMemoryUserDataAccessObject.getInstance();
+
+        User user = new User("arz", "123");
+        userRepository.addUser(user);
+
+        LogoutOutputBoundary successPresenter = new LogoutOutputBoundary() {
+            @Override
+            public void prepareSuccessView(LogoutOutputData user) {
+                assertEquals("arz", user.getUsername());
+            }
+
+            @Override
+            public void prepareFailView(String error) {
+                fail("Use case failure is unexpected.");
+            }
+        };
+
+        LogoutInputBoundary interactor = new LogoutInteractor(userRepository, successPresenter);
+        interactor.execute(inputData);
+    }
 }


### PR DESCRIPTION
The like_plant use case was previously requiring a plant id as input rather than a Plant entity object, which was asymmetric with the edit_plant use case. Unit tests have also been implemented for the three mentioned interactors.
