### PR TITLE
Fix unit tests bug

### DIFF
--- a/src/main/java/data_access/InMemoryImageDataAccessObject.java
+++ b/src/main/java/data_access/InMemoryImageDataAccessObject.java
@@ -19,11 +19,7 @@ public class InMemoryImageDataAccessObject implements ImageDataAccessInterface {
     private final Map<String, BufferedImage> imageStorage = new HashMap<>();
     private static InMemoryImageDataAccessObject instance;
 
-    /**
-     * The private constructor -- if a new instance of this class is to be requested, it should be done
-     * by calling the getInstance() public method.
-     */
-    private InMemoryImageDataAccessObject() {}
+    public InMemoryImageDataAccessObject() {}
 
     /**
      * The method used to retrieve an instance of this class. This way, the DAO is maintained as a singleton.

--- a/src/main/java/data_access/InMemoryPlantDataAccessObject.java
+++ b/src/main/java/data_access/InMemoryPlantDataAccessObject.java
@@ -14,11 +14,7 @@ public class InMemoryPlantDataAccessObject implements PlantDataAccessInterface {
 
     private static InMemoryPlantDataAccessObject instance;
 
-    /**
-     * The private constructor -- if a new instance of this class is to be requested, it should be done
-     * by calling the getInstance() public method.
-     */
-    private InMemoryPlantDataAccessObject() {}
+    public InMemoryPlantDataAccessObject() {}
 
     /**
      * The method used to retrieve an instance of this class. This way, the DAO is maintained as a singleton.

--- a/src/main/java/data_access/InMemoryUserDataAccessObject.java
+++ b/src/main/java/data_access/InMemoryUserDataAccessObject.java
@@ -19,11 +19,7 @@ public class InMemoryUserDataAccessObject implements use_case.UserDataAccessInte
 
     private static InMemoryUserDataAccessObject instance;
 
-    /**
-     * The private constructor -- if a new instance of this class is to be requested, it should be done
-     * by calling the getInstance() public method.
-     */
-    private InMemoryUserDataAccessObject() {}
+    public InMemoryUserDataAccessObject() {}
 
     /**
      * The method used to retrieve an instance of this class. This way, the DAO is maintained as a singleton.

--- a/src/main/java/interface_adapter/like_plant/LikePlantPresenter.java
+++ b/src/main/java/interface_adapter/like_plant/LikePlantPresenter.java
@@ -11,6 +11,7 @@ public class LikePlantPresenter implements LikePlantOutputBoundary {
     }
     @Override
     public void prepareSuccessView() {
+        // the main view should update the like count
         mainViewModel.firePropertyChanged("refresh");
     }
 }

--- a/src/main/java/use_case/like_plant/LikePlantInteractor.java
+++ b/src/main/java/use_case/like_plant/LikePlantInteractor.java
@@ -12,7 +12,10 @@ public class LikePlantInteractor implements LikePlantInputBoundary {
 
     @Override
     public void execute(LikePlantInputData input) {
+        // fetch plant id and tell DAO to like the corresponding plant
         plantDatabase.likePlant(input.getPlant().getFileID());
+
+        // prepare success view (this use case never fails)
         presenter.prepareSuccessView();
     }
 }

--- a/src/main/java/use_case/login/LoginInteractor.java
+++ b/src/main/java/use_case/login/LoginInteractor.java
@@ -21,15 +21,18 @@ public class LoginInteractor implements LoginInputBoundary {
     public void execute(LoginInputData loginInputData) {
         final String username = loginInputData.getUsername();
         final String password = loginInputData.getPassword();
+
         if (!userDataAccessObject.existsByUsername(username)) {
+            // user does not exist
             loginPresenter.prepareFailView(username + ": Account does not exist.");
-        }
-        else {
+        } else {
+            // user exists
             final String pwd = userDataAccessObject.getUser(username).getPassword();
             if (!password.equals(pwd)) {
+                // user exists but password is incorrect
                 loginPresenter.prepareFailView("Incorrect password for \"" + username + "\".");
-            }
-            else {
+            }  else {
+                // user exists and password is correct
                 final User user = userDataAccessObject.getUser(loginInputData.getUsername());
 
                 userDataAccessObject.setCurrentUsername(user.getUsername());

--- a/src/main/java/use_case/logout/LogoutInteractor.java
+++ b/src/main/java/use_case/logout/LogoutInteractor.java
@@ -17,8 +17,13 @@ public class LogoutInteractor implements LogoutInputBoundary {
 
     @Override
     public void execute(LogoutInputData logoutInputData) {
+        // save current user in a local variable
         final String username = logoutInputData.getUsername();
+
+        // log user out of the DAO
         userDataAccessObject.setCurrentUsername(null);
+
+        // prepare success view for the logged out user
         final LogoutOutputData logoutOutputData = new LogoutOutputData(username, false);
         logoutPresenter.prepareSuccessView(logoutOutputData);
     }

--- a/src/test/java/entity/PlantTest.java
+++ b/src/test/java/entity/PlantTest.java
@@ -4,7 +4,9 @@ import static org.junit.Assert.*;
 
 public class PlantTest {
     @Test
-    public void successTest() {
-
+    public void setCommentsTest() {
+        Plant plant = new Plant();
+        plant.setComments("My comments");
+        assertEquals("My comments", plant.getComments());
     }
 }

--- a/src/test/java/entity/PlantTest.java
+++ b/src/test/java/entity/PlantTest.java
@@ -1,4 +1,10 @@
 package entity;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 public class PlantTest {
+    @Test
+    public void successTest() {
+
+    }
 }

--- a/src/test/java/entity/PlantTest.java
+++ b/src/test/java/entity/PlantTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 public class PlantTest {
     @Test
     public void setCommentsTest() {
+        // test the functionality of setComments and getComments
         Plant plant = new Plant();
         plant.setComments("My comments");
         assertEquals("My comments", plant.getComments());

--- a/src/test/java/entity/UserTest.java
+++ b/src/test/java/entity/UserTest.java
@@ -1,4 +1,14 @@
 package entity;
 
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
 public class UserTest {
+    @Test
+    public void setCommentsTest() {
+        User user = new User();
+        user.setUsername("arz");
+        assertEquals("arz", user.getUsername());
+    }
 }

--- a/src/test/java/entity/UserTest.java
+++ b/src/test/java/entity/UserTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertEquals;
 public class UserTest {
     @Test
     public void setCommentsTest() {
+        // test the functionality of setUsername and getUsername
         User user = new User();
         user.setUsername("arz");
         assertEquals("arz", user.getUsername());

--- a/src/test/java/use_case/LikePlantInteractorTest.java
+++ b/src/test/java/use_case/LikePlantInteractorTest.java
@@ -26,12 +26,9 @@ public class LikePlantInteractorTest {
         LikePlantInputData inputData = new LikePlantInputData(plant);
 
         // construct temporary presenter
-        LikePlantOutputBoundary successPresenter = new LikePlantOutputBoundary() {
-            @Override
-            public void prepareSuccessView() {
-                // the like_plant use case should increment the plant's likes from 0 to 1
-                assertEquals(1, plantRepository.fetchPlantByID(plantID).getNumOfLikes());
-            }
+        LikePlantOutputBoundary successPresenter = () -> {
+            // the like_plant use case should increment the plant's likes from 0 to 1
+            assertEquals(1, plantRepository.fetchPlantByID(plantID).getNumOfLikes());
         };
 
         // execute the use case

--- a/src/test/java/use_case/LikePlantInteractorTest.java
+++ b/src/test/java/use_case/LikePlantInteractorTest.java
@@ -18,7 +18,7 @@ public class LikePlantInteractorTest {
         plant.setFileID(plantID);
         LikePlantInputData inputData = new LikePlantInputData(plant);
 
-        PlantDataAccessInterface plantRepository = InMemoryPlantDataAccessObject.getInstance();
+        PlantDataAccessInterface plantRepository = new InMemoryPlantDataAccessObject();
         plantRepository.addPlant(plant);
 
         LikePlantOutputBoundary successPresenter = new LikePlantOutputBoundary() {

--- a/src/test/java/use_case/LikePlantInteractorTest.java
+++ b/src/test/java/use_case/LikePlantInteractorTest.java
@@ -13,21 +13,28 @@ import use_case.like_plant.LikePlantOutputBoundary;
 public class LikePlantInteractorTest {
     @Test
     public void successTest() {
+        // create a new plant
         Plant plant = new Plant();
         ObjectId plantID = new ObjectId();
         plant.setFileID(plantID);
-        LikePlantInputData inputData = new LikePlantInputData(plant);
 
+        // upload plant to an InMemory DAO
         PlantDataAccessInterface plantRepository = new InMemoryPlantDataAccessObject();
         plantRepository.addPlant(plant);
 
+        // create input data
+        LikePlantInputData inputData = new LikePlantInputData(plant);
+
+        // construct temporary presenter
         LikePlantOutputBoundary successPresenter = new LikePlantOutputBoundary() {
             @Override
             public void prepareSuccessView() {
+                // the like_plant use case should increment the plant's likes from 0 to 1
                 assertEquals(1, plantRepository.fetchPlantByID(plantID).getNumOfLikes());
             }
         };
 
+        // execute the use case
         LikePlantInputBoundary interactor = new LikePlantInteractor(plantRepository, successPresenter);
         interactor.execute(inputData);
     }

--- a/src/test/java/use_case/LoginInteractorTest.java
+++ b/src/test/java/use_case/LoginInteractorTest.java
@@ -9,20 +9,25 @@ import static org.junit.Assert.*;
 public class LoginInteractorTest {
     @Test
     public void successTest() {
-        LoginInputData inputData = new LoginInputData("arz", "123");
+        // create user and save to DAO
         UserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
-
         User user = new User("arz", "123");
         userRepository.addUser(user);
 
+        // create input data with correct password
+        LoginInputData inputData = new LoginInputData("arz", "123");
+
+        // construct temporary presenter
         LoginOutputBoundary successPresenter = new LoginOutputBoundary() {
             @Override
             public void prepareSuccessView(LoginOutputData user) {
+                // the current user should be "arz"
                 assertEquals("arz", user.getUsername());
             }
 
             @Override
             public void prepareFailView(String error) {
+                // the use case should not fail since the password was correct
                 fail("Use case failure is unexpected.");
             }
 
@@ -30,6 +35,7 @@ public class LoginInteractorTest {
             public void switchToStartView() {}
         };
 
+        // execute the use case
         LoginInputBoundary interactor = new LoginInteractor(userRepository, successPresenter);
         interactor.execute(inputData);
     }
@@ -37,20 +43,25 @@ public class LoginInteractorTest {
 
     @Test
     public void failurePasswordMismatchTest() {
-        LoginInputData inputData = new LoginInputData("arz", "wrong");
+        // create a new user and save to DAO
         UserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
-
         User user = new User("arz", "123");
         userRepository.addUser(user);
 
+        // create input data with incorrect password
+        LoginInputData inputData = new LoginInputData("arz", "wrong");
+
+        // construct temporary presenter
         LoginOutputBoundary failurePresenter = new LoginOutputBoundary() {
             @Override
             public void prepareSuccessView(LoginOutputData user) {
+                // the use case should fail since the password was incorrect
                 fail("Use case success is unexpected.");
             }
 
             @Override
             public void prepareFailView(String error) {
+                // check that the error message is correct
                 assertEquals("Incorrect password for \"arz\".", error);
             }
 
@@ -58,23 +69,30 @@ public class LoginInteractorTest {
             public void switchToStartView() {}
         };
 
+        // execute use case
         LoginInputBoundary interactor = new LoginInteractor(userRepository, failurePresenter);
         interactor.execute(inputData);
     }
 
     @Test
     public void failureUserDoesNotExistTest() {
-        LoginInputData inputData = new LoginInputData("arz", "123");
+        // initialize an empty DAO (do not save a user for this test)
         UserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
+        // create input data for any (non-existent) user
+        LoginInputData inputData = new LoginInputData("arz", "123");
+
+        // construct temporary presenter
         LoginOutputBoundary failurePresenter = new LoginOutputBoundary() {
             @Override
             public void prepareSuccessView(LoginOutputData user) {
+                // use case should fail since user does not exist
                 fail("Use case success is unexpected.");
             }
 
             @Override
             public void prepareFailView(String error) {
+                // check that the error message is correct
                 assertEquals("arz: Account does not exist.", error);
             }
 
@@ -82,6 +100,7 @@ public class LoginInteractorTest {
             public void switchToStartView() {}
         };
 
+        // execute use case
         LoginInputBoundary interactor = new LoginInteractor(userRepository, failurePresenter);
         interactor.execute(inputData);
     }

--- a/src/test/java/use_case/LoginInteractorTest.java
+++ b/src/test/java/use_case/LoginInteractorTest.java
@@ -10,7 +10,7 @@ public class LoginInteractorTest {
     @Test
     public void successTest() {
         LoginInputData inputData = new LoginInputData("arz", "123");
-        UserDataAccessInterface userRepository = InMemoryUserDataAccessObject.getInstance();
+        UserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         User user = new User("arz", "123");
         userRepository.addUser(user);
@@ -38,7 +38,7 @@ public class LoginInteractorTest {
     @Test
     public void failurePasswordMismatchTest() {
         LoginInputData inputData = new LoginInputData("arz", "wrong");
-        UserDataAccessInterface userRepository = InMemoryUserDataAccessObject.getInstance();
+        UserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         User user = new User("arz", "123");
         userRepository.addUser(user);
@@ -65,7 +65,7 @@ public class LoginInteractorTest {
     @Test
     public void failureUserDoesNotExistTest() {
         LoginInputData inputData = new LoginInputData("arz", "123");
-        UserDataAccessInterface userRepository = InMemoryUserDataAccessObject.getInstance();
+        UserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         LoginOutputBoundary failurePresenter = new LoginOutputBoundary() {
             @Override

--- a/src/test/java/use_case/LogoutInteractorTest.java
+++ b/src/test/java/use_case/LogoutInteractorTest.java
@@ -11,12 +11,15 @@ import static org.junit.Assert.fail;
 public class LogoutInteractorTest {
     @Test
     public void successTest() {
-        LogoutInputData inputData = new LogoutInputData("arz");
+        // initialize DAO and add a new user to it
         UserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
-
         User user = new User("arz", "123");
         userRepository.addUser(user);
 
+        // create input data corresponding to the existing user
+        LogoutInputData inputData = new LogoutInputData("arz");
+
+        // construct temporary presenter
         LogoutOutputBoundary successPresenter = new LogoutOutputBoundary() {
             @Override
             public void prepareSuccessView(LogoutOutputData user) {
@@ -29,6 +32,7 @@ public class LogoutInteractorTest {
             }
         };
 
+        // execute use case
         LogoutInputBoundary interactor = new LogoutInteractor(userRepository, successPresenter);
         interactor.execute(inputData);
     }

--- a/src/test/java/use_case/LogoutInteractorTest.java
+++ b/src/test/java/use_case/LogoutInteractorTest.java
@@ -12,7 +12,7 @@ public class LogoutInteractorTest {
     @Test
     public void successTest() {
         LogoutInputData inputData = new LogoutInputData("arz");
-        UserDataAccessInterface userRepository = InMemoryUserDataAccessObject.getInstance();
+        UserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         User user = new User("arz", "123");
         userRepository.addUser(user);


### PR DESCRIPTION
The tests were previously based on the InMemory DAO's getInstance method, which maintains a single DAO across every test. This led to faulty behaviour when running the tests simultaneously; fixed by making the DAO constructors public and instantiating them directly.